### PR TITLE
Add Shu Yang's Project Portfolio Page

### DIFF
--- a/docs/team/shuyangk.md
+++ b/docs/team/shuyangk.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Koh Shu Yang's Project Portfolio Page
+---
+
+### Project: BandConnect+
+
+BandConnect+ is a desktop address book application used by musicians and producers to keep track of their contacts. 
+The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **New Feature**: To be added soon.
+  * What it does: To be added soon.
+  * Justification: To be added soon.
+  * Highlights: To be added soon.
+  * Credits: *To be added soon.*
+
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2324s1.github.io/tp-dashboard/?search=shuyangk&breakdown=false&sort=groupTitle%20dsc&sortWithin=title&since=2023-09-22&timeframe=commit&mergegroup=&groupSelect=groupByRepos)
+
+* **Project management**:
+  * To be added soon.
+
+* **Enhancements to existing features**:
+  * To be added soon.
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#29](https://github.com/nus-cs2103-AY2324S1/ip/pull/29), [\#52](https://github.com/nus-cs2103-AY2324S1/ip/pull/52)
+  * Contributed to forum discussions (To be added soon)
+
+* **Tools**:
+  * To be added soon.
+  
+  


### PR DESCRIPTION
The project portfolio page(PPP) is used to describe contribution to the project. It tracks various aspects of contribution such as code written and forum participation.

Having the PPP allows for people to view all contributions in one place.