### PR TITLE
Add validity checks for instrument and genre names with more tests

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -28,6 +28,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {
@@ -57,9 +58,12 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
             editMusicianDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editMusicianDescriptor::setTags);
-        parseInstrumentsForEdit(argMultimap.getAllValues(PREFIX_INSTRUMENT)).ifPresent(editMusicianDescriptor::setInstruments);
-        parseGenresForEdit(argMultimap.getAllValues(PREFIX_GENRE)).ifPresent(editMusicianDescriptor::setGenres);
+        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
+                .ifPresent(editMusicianDescriptor::setTags);
+        parseInstrumentsForEdit(argMultimap.getAllValues(PREFIX_INSTRUMENT))
+                .ifPresent(editMusicianDescriptor::setInstruments);
+        parseGenresForEdit(argMultimap.getAllValues(PREFIX_GENRE))
+                .ifPresent(editMusicianDescriptor::setGenres);
 
         if (!editMusicianDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -58,8 +58,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             editMusicianDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editMusicianDescriptor::setTags);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_INSTRUMENT)).ifPresent(editMusicianDescriptor::setInstruments);
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_GENRE)).ifPresent(editMusicianDescriptor::setGenres);
+        parseInstrumentsForEdit(argMultimap.getAllValues(PREFIX_INSTRUMENT)).ifPresent(editMusicianDescriptor::setInstruments);
+        parseGenresForEdit(argMultimap.getAllValues(PREFIX_GENRE)).ifPresent(editMusicianDescriptor::setGenres);
 
         if (!editMusicianDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
@@ -83,4 +83,36 @@ public class EditCommandParser implements Parser<EditCommand> {
         return Optional.of(ParserUtil.parseTags(tagSet));
     }
 
+    /**
+     * Parses {@code Collection<String> instruments} into a {@code Set<Tag>} if {@code instruments} is a valid
+     * collection of instruments.
+     * If {@code instruments} contain only one element which is an empty string, it will be parsed into a
+     * {@code Set<Tag>} containing zero instruments.
+     */
+    private Optional<Set<Tag>> parseInstrumentsForEdit(Collection<String> instruments) throws ParseException {
+        assert instruments != null;
+
+        if (instruments.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> instrumentSet = instruments.size() == 1 && instruments.contains("")
+                ? Collections.emptySet() : instruments;
+        return Optional.of(ParserUtil.parseInstruments(instrumentSet));
+    }
+
+    /**
+     * Parses {@code Collection<String> genres} into a {@code Set<Tag>} if {@code genres} is a valid collection of
+     * genres.
+     * If {@code genres} contain only one element which is an empty string, it will be parsed into a {@code Set<Tag>}
+     * containing zero genres.
+     */
+    private Optional<Set<Tag>> parseGenresForEdit(Collection<String> genres) throws ParseException {
+        assert genres != null;
+
+        if (genres.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> genreSet = genres.size() == 1 && genres.contains("") ? Collections.emptySet() : genres;
+        return Optional.of(ParserUtil.parseGenres(genreSet));
+    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,10 +78,6 @@ public interface Model {
      */
     void setMusician(Musician target, Musician editedMusician);
 
-    boolean hasBand(Band band);
-
-    void addBand(Band band);
-
     /** Returns an unmodifiable view of the filtered musician list */
     ObservableList<Musician> getFilteredMusicianList();
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedGenre.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGenre.java
@@ -1,0 +1,32 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.tag.Genre;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Genre}.
+ */
+public class JsonAdaptedGenre extends JsonAdaptedTag {
+
+    @JsonCreator
+    public JsonAdaptedGenre(String genre) {
+        super(genre);
+    }
+
+    public JsonAdaptedGenre(Tag source) {
+        super(source);
+    }
+
+    @Override
+    public Tag toModelType() throws IllegalValueException {
+        if (!Genre.isValidGenreName(super.getTagName())) {
+            throw new IllegalValueException(Genre.MESSAGE_CONSTRAINTS);
+        }
+        return new Genre(super.getTagName());
+    }
+
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedInstrument.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedInstrument.java
@@ -1,0 +1,32 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.tag.Instrument;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link Instrument}.
+ */
+public class JsonAdaptedInstrument extends JsonAdaptedTag {
+
+    @JsonCreator
+    public JsonAdaptedInstrument(String instrument) {
+        super(instrument);
+    }
+
+    public JsonAdaptedInstrument(Tag source) {
+        super(source);
+    }
+
+    @Override
+    public Tag toModelType() throws IllegalValueException {
+        if (!Instrument.isValidInstrumentName(super.getTagName())) {
+            throw new IllegalValueException(Instrument.MESSAGE_CONSTRAINTS);
+        }
+        return new Instrument(super.getTagName());
+    }
+
+
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedMusician.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMusician.java
@@ -27,8 +27,8 @@ class JsonAdaptedMusician {
     private final String phone;
     private final String email;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
-    private final List<JsonAdaptedTag> instruments = new ArrayList<>();
-    private final List<JsonAdaptedTag> genres = new ArrayList<>();
+    private final List<JsonAdaptedInstrument> instruments = new ArrayList<>();
+    private final List<JsonAdaptedGenre> genres = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedMusician} with the given musician details.
@@ -37,8 +37,8 @@ class JsonAdaptedMusician {
     public JsonAdaptedMusician(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                                @JsonProperty("email") String email,
                                @JsonProperty("tags") List<JsonAdaptedTag> tags,
-                               @JsonProperty("instruments") List<JsonAdaptedTag> instruments,
-                               @JsonProperty("genres") List<JsonAdaptedTag> genres) {
+                               @JsonProperty("instruments") List<JsonAdaptedInstrument> instruments,
+                               @JsonProperty("genres") List<JsonAdaptedGenre> genres) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -64,10 +64,10 @@ class JsonAdaptedMusician {
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
         instruments.addAll(source.getInstruments().stream()
-                .map(JsonAdaptedTag::new)
+                .map(JsonAdaptedInstrument::new)
                 .collect(Collectors.toList()));
         genres.addAll(source.getGenres().stream()
-                .map(JsonAdaptedTag::new)
+                .map(JsonAdaptedGenre::new)
                 .collect(Collectors.toList()));
     }
 
@@ -114,8 +114,6 @@ class JsonAdaptedMusician {
             throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
         }
         final Email modelEmail = new Email(email);
-
-
 
         final Set<Tag> modelTags = new HashSet<>(musicianTags);
         final Set<Tag> modelInstruments = new HashSet<>(musicianInstruments);

--- a/src/test/java/seedu/address/model/tag/GenreTest.java
+++ b/src/test/java/seedu/address/model/tag/GenreTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model.tag;
+
+import static seedu.address.model.tag.Genre.VALID_GENRES;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class GenreTest extends TagTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Genre(null));
+    }
+
+    @Test
+    public void constructor_invalidGenreName_throwsIllegalArgumentException() {
+        String invalidGenreName = "foo";
+        if (!VALID_GENRES.contains(invalidGenreName)) {
+            assertThrows(IllegalArgumentException.class, () -> new Genre(invalidGenreName));
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/tag/InstrumentTest.java
+++ b/src/test/java/seedu/address/model/tag/InstrumentTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model.tag;
+
+import static seedu.address.model.tag.Instrument.VALID_INSTRUMENTS;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class InstrumentTest extends TagTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Instrument(null));
+    }
+
+    @Test
+    public void constructor_invalidInstrumentName_throwsIllegalArgumentException() {
+        String invalidInstrumentName = "foo";
+        if (!VALID_INSTRUMENTS.contains(invalidInstrumentName)) {
+            assertThrows(IllegalArgumentException.class, () -> new Genre(invalidInstrumentName));
+        }
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedMusicianTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMusicianTest.java
@@ -30,11 +30,11 @@ public class JsonAdaptedMusicianTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedTag> VALID_INSTRUMENTS = BENSON.getInstruments().stream()
-            .map(JsonAdaptedTag::new)
+    private static final List<JsonAdaptedInstrument> VALID_INSTRUMENTS = BENSON.getInstruments().stream()
+            .map(JsonAdaptedInstrument::new)
             .collect(Collectors.toList());
-    private static final List<JsonAdaptedTag> VALID_GENRES = BENSON.getGenres().stream()
-            .map(JsonAdaptedTag::new)
+    private static final List<JsonAdaptedGenre> VALID_GENRES = BENSON.getGenres().stream()
+            .map(JsonAdaptedGenre::new)
             .collect(Collectors.toList());
 
     @Test
@@ -94,8 +94,6 @@ public class JsonAdaptedMusicianTest {
         assertThrows(IllegalValueException.class, expectedMessage, musician::toModelType);
     }
 
-
-
     @Test
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
@@ -103,6 +101,26 @@ public class JsonAdaptedMusicianTest {
         JsonAdaptedMusician musician =
                 new JsonAdaptedMusician(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                         invalidTags, VALID_INSTRUMENTS, VALID_GENRES);
+        assertThrows(IllegalValueException.class, musician::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidInstruments_throwsIllegalValueException() {
+        List<JsonAdaptedInstrument> invalidInstruments = new ArrayList<>(VALID_INSTRUMENTS);
+        invalidInstruments.add(new JsonAdaptedInstrument(INVALID_INSTRUMENT));
+        JsonAdaptedMusician musician =
+                new JsonAdaptedMusician(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_TAGS, invalidInstruments, VALID_GENRES);
+        assertThrows(IllegalValueException.class, musician::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidGenres_throwsIllegalValueException() {
+        List<JsonAdaptedGenre> invalidGenres = new ArrayList<>(VALID_GENRES);
+        invalidGenres.add(new JsonAdaptedGenre(INVALID_GENRE));
+        JsonAdaptedMusician musician =
+                new JsonAdaptedMusician(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                        VALID_TAGS, VALID_INSTRUMENTS, invalidGenres);
         assertThrows(IllegalValueException.class, musician::toModelType);
     }
 }


### PR DESCRIPTION
For this PR, I:
- Enforce validity checks so that the user can only input valid instrument and genre names (within pre-defined values).
- Add JSON support for instrument and genre tags so that their validities can be checked upon startup of the application when reading from the JSON file
- Add more tests to test the Genre, Instrument, JsonAdaptedGenre, JsonAdaptedInstrument, JsonAdaptedMusician classes

Upon merging this PR, it fixes #75 