### PR TITLE
Implement ListBandCommand using band index

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListBandCommand.java
@@ -2,10 +2,10 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.band.BandNameContainsKeywordsPredicate;
 
 /**
  * Lists all musicians in a band input by the user.
@@ -15,21 +15,20 @@ public class ListBandCommand extends Command {
     public static final String COMMAND_WORD = "listb";
 
     public static final Object MESSAGE_USAGE = COMMAND_WORD + ": Finds all musicians who are part of "
-        + "the specified band (case-insensitive) and displays them as a list with index numbers.\n"
-        + "Parameters: BAND_NAME...\n"
-        + "Example: " + COMMAND_WORD + " ace jazz";
+        + "the band at the specified index and displays them as a list with index numbers.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
 
-    private final BandNameContainsKeywordsPredicate predicate;
+    private final Index targetIndex;
 
-    public ListBandCommand(BandNameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
+    public ListBandCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredBandList(predicate);
-        model.updateFilteredMusicianListFromBands();
+        model.updateFilteredMusicianList(targetIndex.getZeroBased());
         return new CommandResult(
             String.format(Messages.MESSAGE_MUSICIANS_LISTED_OVERVIEW, model.getFilteredMusicianList().size()));
     }

--- a/src/main/java/seedu/address/logic/parser/ListBandCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListBandCommandParser.java
@@ -2,9 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ListBandCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.band.BandNameContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new ListBandCommand object.
@@ -13,12 +13,12 @@ public class ListBandCommandParser implements Parser<ListBandCommand> {
 
     @Override
     public ListBandCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ListBandCommand(index);
+        } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListBandCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListBandCommand.MESSAGE_USAGE), pe);
         }
-
-        return new ListBandCommand(new BandNameContainsKeywordsPredicate(trimmedArgs));
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -118,6 +118,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(band);
         return bands.contains(band);
     }
+
     /**
      * Returns true if the musician already exists in the band.
      */
@@ -126,6 +127,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(musicianIndex);
         return bands.hasMusician(bandIndex, musicians.getMusician(musicianIndex));
     }
+
     /**
      * Adds a musician to a band.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -87,6 +87,12 @@ public interface Model {
      */
     void updateFilteredMusicianList(Predicate<Musician> predicate);
 
+    /**
+     * Updates the {@code FilteredMusicianList} to contain all musicians in the {@code Band}
+     * at the specified index.
+     */
+    void updateFilteredMusicianList(int bandIndex);
+
     /** Returns an unmodifiable view of the filtered band list */
     ObservableList<Band> getFilteredBandList();
 
@@ -95,7 +101,7 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredBandList(Predicate<Band> predicate);
-    void updateFilteredMusicianListFromBands();
+
     /**
      * Returns true if a band with the same identity as {@code band} exists in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.band.Band;
 import seedu.address.model.musician.Musician;
+import seedu.address.model.musician.MusicianInBandPredicate;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -131,6 +132,7 @@ public class ModelManager implements Model {
         requireNonNull(musicianIndex);
         return addressBook.hasMusicianInBand(bandIndex, musicianIndex);
     }
+
     @Override
     public void addMusicianToBand(int bandIndex, int musicianIndex) {
         requireNonNull(bandIndex);
@@ -157,14 +159,10 @@ public class ModelManager implements Model {
         filteredMusicians.setPredicate(predicate);
     }
 
-    /**
-     * Updates the {@code FilteredMusicianList} to contain all musicians in the {@code FilteredBands}.
-     */
-    public void updateFilteredMusicianListFromBands() {
-        requireNonNull(filteredBands);
-        for (Band b : filteredBands) {
-            filteredMusicians.addAll(b.getMusicians());
-        }
+    @Override
+    public void updateFilteredMusicianList(int bandIndex) {
+        Predicate<Musician> predicate = new MusicianInBandPredicate(filteredBands.get(bandIndex));
+        filteredMusicians.setPredicate(predicate);
     }
 
     //=========== Filtered Band List Accessors =============================================================

--- a/src/main/java/seedu/address/model/musician/MusicianInBandPredicate.java
+++ b/src/main/java/seedu/address/model/musician/MusicianInBandPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.musician;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.band.Band;
+
+/**
+ * Tests that a {@code Musician} is contained in a {@code Band}.
+ */
+public class MusicianInBandPredicate implements Predicate<Musician> {
+
+    private final Band bandToCheck;
+
+    public MusicianInBandPredicate(Band bandToCheck) {
+        this.bandToCheck = bandToCheck;
+    }
+
+    @Override
+    public boolean test(Musician musician) {
+        return bandToCheck.getMusicians().contains(musician);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MusicianInBandPredicate)) {
+            return false;
+        }
+
+        MusicianInBandPredicate otherMusicianInBandPredicate = (MusicianInBandPredicate) other;
+        return bandToCheck.equals(otherMusicianInBandPredicate.bandToCheck);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("bandToCheck", bandToCheck).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -166,17 +166,17 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateFilteredMusicianList(int bandIndex) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void updateFilteredBandList(Predicate<Band> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public boolean hasBand(Band band) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredMusicianListFromBands() {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
In this branch, I re-implemented the ListBandCommand in the following ways:

- User inputs the band index instead of the band name. This ensures that the band to be queried will be unique.
- Implement a new Predicate, `MusicianInBandPredicate`, that tests if a Musician is contained within the specified Band.

This change will also render `BandNameContainsKeywordsPredicate` redundant for now.