### PR TITLE
Add unit tests for UniqueBandList

### DIFF
--- a/src/main/java/seedu/address/model/band/UniqueBandList.java
+++ b/src/main/java/seedu/address/model/band/UniqueBandList.java
@@ -85,6 +85,29 @@ public class UniqueBandList implements Iterable<Band> {
 
         internalList.setAll(band);
     }
+
+    /**
+     * Replaces the contents of this list with all bands in {@code replacement}.
+     * {@code replacement} must not contain duplicate bands.
+     */
+    public void setBands(UniqueBandList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code bands}.
+     * {@code bands} must not contain duplicate musicians.
+     */
+    public void setBands(List<Band> bands) {
+        requireAllNonNull(bands);
+        if (!bandsAreUnique(bands)) {
+            throw new DuplicateBandException();
+        }
+
+        internalList.setAll(bands);
+    }
+
     /**
      * Removes the equivalent band from the list.
      * The band must exist in the list.

--- a/src/test/java/seedu/address/model/band/BandNameTest.java
+++ b/src/test/java/seedu/address/model/band/BandNameTest.java
@@ -6,7 +6,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class NameTest {
+public class BandNameTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {

--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -1,0 +1,185 @@
+package seedu.address.model.band;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalBands.ACE;
+import static seedu.address.testutil.TypicalBands.BOOM;
+import static seedu.address.testutil.TypicalBands.CANDY;
+import static seedu.address.testutil.TypicalBands.ELISE;
+import static seedu.address.testutil.TypicalMusicians.ALICE;
+import static seedu.address.testutil.TypicalMusicians.ELLE;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.band.exceptions.BandNotFoundException;
+import seedu.address.model.band.exceptions.DuplicateBandException;
+import seedu.address.model.musician.exceptions.DuplicateMusicianException;
+import seedu.address.testutil.BandBuilder;
+
+public class UniqueBandListTest {
+
+    private final UniqueBandList uniqueBandList = new UniqueBandList();
+
+    @Test
+    public void contains_nullBand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.contains(null));
+    }
+
+    @Test
+    public void contains_bandNotInList_returnsFalse() {
+        assertFalse(uniqueBandList.contains(ACE));
+    }
+
+    @Test
+    public void contains_bandInList_returnsTrue() {
+        uniqueBandList.add(ACE);
+        assertTrue(uniqueBandList.contains(ACE));
+    }
+
+    @Test
+    public void add_nullBand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.add(null));
+    }
+
+    @Test
+    public void add_duplicateBand_throwsDuplicateBandException() {
+        uniqueBandList.add(ACE);
+        assertThrows(DuplicateBandException.class, () -> uniqueBandList.add(ACE));
+    }
+
+    @Test
+    public void add_duplicateBandWithNewMusician_throwsDuplicateBandException() {
+        uniqueBandList.add(ACE);
+        Band newAce = new BandBuilder(ACE).withMusicians(ALICE)
+            .build();
+        assertThrows(DuplicateBandException.class, () -> uniqueBandList.add(newAce));
+    }
+
+    @Test
+    public void setBand_nullTargetBand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.setBand(null, ACE));
+    }
+
+    @Test
+    public void setBand_nullEditedBand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.setBand(ACE, null));
+    }
+
+    @Test
+    public void setBand_targetBandNotInList_throwsBandNotFoundException() {
+        assertThrows(BandNotFoundException.class, () -> uniqueBandList.setBand(ACE, ACE));
+    }
+
+    @Test
+    public void remove_nullBand_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.remove(null));
+    }
+
+    @Test
+    public void remove_bandDoesNotExist_throwsBandNotFoundException() {
+        assertThrows(BandNotFoundException.class, () -> uniqueBandList.remove(ACE));
+    }
+
+    @Test
+    public void remove_existingBand_withoutMusicians_removesBand() {
+        uniqueBandList.add(ACE);
+        uniqueBandList.remove(ACE);
+        UniqueBandList expectedUniqueBandList = new UniqueBandList();
+        assertEquals(expectedUniqueBandList, uniqueBandList);
+    }
+
+    @Test
+    public void remove_existingBand_withMusicians_removesBand() {
+        uniqueBandList.add(CANDY);
+        uniqueBandList.remove(CANDY);
+        UniqueBandList expectedUniqueBandList = new UniqueBandList();
+        assertEquals(expectedUniqueBandList, uniqueBandList);
+    }
+
+    @Test
+    public void setBands_uniqueBandList_replacesOwnListWithProvidedUniqueBandList() {
+        uniqueBandList.add(ACE);
+        UniqueBandList expectedUniqueBandList = new UniqueBandList();
+        expectedUniqueBandList.add(BOOM);
+        uniqueBandList.setBands(expectedUniqueBandList);
+        assertEquals(expectedUniqueBandList, uniqueBandList);
+    }
+
+    @Test
+    public void setBands_nullList_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueBandList.setBands((List<Band>) null));
+    }
+
+    @Test
+    public void setBands_list_replacesOwnListWithProvidedList() {
+        uniqueBandList.add(ACE);
+        List<Band> bandList = Collections.singletonList(BOOM);
+        uniqueBandList.setBands(bandList);
+        UniqueBandList expectedUniqueBandList = new UniqueBandList();
+        expectedUniqueBandList.add(BOOM);
+        assertEquals(expectedUniqueBandList, uniqueBandList);
+    }
+
+    @Test
+    public void setBands_listWithDuplicateBands_throwsDuplicateBandException() {
+        List<Band> listWithDuplicateBands = Arrays.asList(ACE, ACE);
+        assertThrows(DuplicateBandException.class, () -> uniqueBandList.setBands(
+            listWithDuplicateBands));
+    }
+
+    @Test
+    public void hasMusician_nullMusician_throwsNullPointerException() {
+        uniqueBandList.add(ACE);
+        assertThrows(NullPointerException.class, () -> uniqueBandList.hasMusician
+            (0, null));
+    }
+
+    @Test
+    public void hasMusician_bandWithoutMusicians_returnsFalse() {
+        uniqueBandList.add(ACE);
+        assertFalse(uniqueBandList.hasMusician(0, ALICE));
+    }
+
+    @Test
+    public void hasMusician_bandWithMusicians_correctMusician_returnsTrue() {
+        uniqueBandList.add(ELISE);
+        assertTrue(uniqueBandList.hasMusician(0, ELLE));
+    }
+
+    @Test
+    public void hasMusician_bandWithMusicians_wrongMusician_returnsFalse() {
+        uniqueBandList.add(ELISE);
+        assertFalse(uniqueBandList.hasMusician(0, ALICE));
+    }
+
+    @Test
+    public void addMusician_nullMusician_throwsNullPointerException() {
+        uniqueBandList.add(ACE);
+        assertThrows(NullPointerException.class, () -> uniqueBandList.addMusician
+            (0, null));
+    }
+
+    @Test
+    public void addMusician_duplicateMusician_throwsDuplicateMusicianException() {
+        uniqueBandList.add(ELISE);
+        assertThrows(DuplicateMusicianException.class, () -> uniqueBandList.addMusician
+            (0, ELLE));
+    }
+
+    @Test
+    public void asUnmodifiableObservableList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, ()
+            -> uniqueBandList.asUnmodifiableObservableList().remove(0));
+    }
+
+    @Test
+    public void toStringMethod() {
+        assertEquals(uniqueBandList.asUnmodifiableObservableList().toString(), uniqueBandList.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -87,7 +87,7 @@ public class UniqueBandListTest {
     }
 
     @Test
-    public void remove_existingBand_withoutMusicians_removesBand() {
+    public void remove_existingBandWithoutMusicians_removesBand() {
         uniqueBandList.add(ACE);
         uniqueBandList.remove(ACE);
         UniqueBandList expectedUniqueBandList = new UniqueBandList();
@@ -95,7 +95,7 @@ public class UniqueBandListTest {
     }
 
     @Test
-    public void remove_existingBand_withMusicians_removesBand() {
+    public void remove_existingBandWithMusicians_removesBand() {
         uniqueBandList.add(CANDY);
         uniqueBandList.remove(CANDY);
         UniqueBandList expectedUniqueBandList = new UniqueBandList();
@@ -129,15 +129,13 @@ public class UniqueBandListTest {
     @Test
     public void setBands_listWithDuplicateBands_throwsDuplicateBandException() {
         List<Band> listWithDuplicateBands = Arrays.asList(ACE, ACE);
-        assertThrows(DuplicateBandException.class, () -> uniqueBandList.setBands(
-            listWithDuplicateBands));
+        assertThrows(DuplicateBandException.class, () -> uniqueBandList.setBands(listWithDuplicateBands));
     }
 
     @Test
     public void hasMusician_nullMusician_throwsNullPointerException() {
         uniqueBandList.add(ACE);
-        assertThrows(NullPointerException.class, () -> uniqueBandList.hasMusician
-            (0, null));
+        assertThrows(NullPointerException.class, () -> uniqueBandList.hasMusician(0, null));
     }
 
     @Test
@@ -147,13 +145,13 @@ public class UniqueBandListTest {
     }
 
     @Test
-    public void hasMusician_bandWithMusicians_correctMusician_returnsTrue() {
+    public void hasMusician_musicianInBand_returnsTrue() {
         uniqueBandList.add(ELISE);
         assertTrue(uniqueBandList.hasMusician(0, ELLE));
     }
 
     @Test
-    public void hasMusician_bandWithMusicians_wrongMusician_returnsFalse() {
+    public void hasMusician_musicianNotInBand_returnsFalse() {
         uniqueBandList.add(ELISE);
         assertFalse(uniqueBandList.hasMusician(0, ALICE));
     }
@@ -161,15 +159,14 @@ public class UniqueBandListTest {
     @Test
     public void addMusician_nullMusician_throwsNullPointerException() {
         uniqueBandList.add(ACE);
-        assertThrows(NullPointerException.class, () -> uniqueBandList.addMusician
-            (0, null));
+        assertThrows(NullPointerException.class, () -> uniqueBandList.addMusician(
+            0, null));
     }
 
     @Test
     public void addMusician_duplicateMusician_throwsDuplicateMusicianException() {
         uniqueBandList.add(ELISE);
-        assertThrows(DuplicateMusicianException.class, () -> uniqueBandList.addMusician
-            (0, ELLE));
+        assertThrows(DuplicateMusicianException.class, () -> uniqueBandList.addMusician(0, ELLE));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalBands.java
+++ b/src/test/java/seedu/address/testutil/TypicalBands.java
@@ -1,12 +1,10 @@
 package seedu.address.testutil;
 
 import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.BENSON;
+import static seedu.address.testutil.TypicalMusicians.BOB;
 import static seedu.address.testutil.TypicalMusicians.CARL;
 import static seedu.address.testutil.TypicalMusicians.DANIEL;
 import static seedu.address.testutil.TypicalMusicians.ELLE;
-import static seedu.address.testutil.TypicalMusicians.FIONA;
-import static seedu.address.testutil.TypicalMusicians.GEORGE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,19 +18,29 @@ import seedu.address.model.band.Band;
  */
 public class TypicalBands {
 
+    // Bands without Musicians
+
     public static final Band ACE = new BandBuilder().withName("Ace Jazz")
-        .withGenres("jazz").withMusicians(ALICE, BENSON, CARL).build();
+        .withGenres("jazz").build();
 
     public static final Band BOOM = new BandBuilder().withName("Boom Rock")
-        .withGenres("rock").withMusicians(DANIEL, ELLE).build();
+        .withGenres("rock").build();
+
+    // Bands with Musicians
 
     public static final Band CANDY = new BandBuilder().withName("Candy Pop")
-        .withGenres("pop").withMusicians(FIONA, GEORGE).build();
+        .withGenres("pop").withMusicians(ALICE, BOB).build();
+
+    public static final Band DRAGON = new BandBuilder().withName("Dragon Metal")
+        .withGenres("metal").withMusicians(CARL, DANIEL).build();
+
+    public static final Band ELISE = new BandBuilder().withName("Elise Classical")
+        .withGenres("classical").withMusicians(ELLE).build();
 
 
     private TypicalBands() {} // prevents instantiation
 
     public static List<Band> getTypicalBands() {
-        return new ArrayList<>(Arrays.asList(ACE, BOOM, CANDY));
+        return new ArrayList<>(Arrays.asList(ACE, BOOM, CANDY, DRAGON, ELISE));
     }
 }


### PR DESCRIPTION
Similar to the `UniqueMusicianList`, there is a need to test if the `UniqueBandList` truly maintains its invariant that all its elements are unique. It forms the basis of many Band-related methods, hence the correctness of its implementation is critical.

This commit contains unit tests to test the correctness of the `UniqueBandList` methods, most of which have similar implementations as those in `UniqueMusicianListTest`. A few additional methods are added to test the `hasMusician` and `addMusician` methods.