### PR TITLE
Unit test for findb command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindBandCommand.java
@@ -33,7 +33,10 @@ public class FindBandCommand extends Command {
         requireNonNull(model);
         model.updateFilteredBandMusicianList(predicate);
 
-        if (model.getFilteredBandList().size() > 1) {
+        // If the band exists, filtered band list is guaranteed to have only one band
+        // If filtered band list size > 1 or size == 1 but the band filtered does not pass the predicate,
+        // it means that the band name is invalid
+        if (model.getFilteredBandList().size() > 1 || !predicate.test(model.getFilteredBandList().get(0))) {
             throw new CommandException(Messages.MESSAGE_UNKNOWN_BAND);
         }
 

--- a/src/main/java/seedu/address/logic/commands/FindBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindBandCommand.java
@@ -33,9 +33,10 @@ public class FindBandCommand extends Command {
         requireNonNull(model);
         model.updateFilteredBandMusicianList(predicate);
 
-        // If the band exists, filtered band list is guaranteed to have only one band
+        // If the band exists, filtered band list is guaranteed to have only one band,
+        // (because add a band enforce no band with the same name (case-insensitive) is allowed).
         // If filtered band list size > 1 or size == 1 but the band filtered does not pass the predicate,
-        // it means that the band name is invalid
+        // it means that the band name is invalid, exception is thrown.
         if (model.getFilteredBandList().size() > 1 || !predicate.test(model.getFilteredBandList().get(0))) {
             throw new CommandException(Messages.MESSAGE_UNKNOWN_BAND);
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.band.Band;
 import seedu.address.model.musician.Musician;
 import seedu.address.model.musician.MusicianInBandPredicate;
@@ -193,7 +194,7 @@ public class ModelManager implements Model {
         if (filteredBands.size() == 0) {
             updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
             updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
-            return;
+
         }
 
         Predicate<Musician> musicianPredicate = new MusicianInBandPredicate(filteredBands.get(0));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.band.Band;
 import seedu.address.model.musician.Musician;
 import seedu.address.model.musician.MusicianInBandPredicate;
@@ -194,7 +193,7 @@ public class ModelManager implements Model {
         if (filteredBands.size() == 0) {
             updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
             updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
-
+            return;
         }
 
         Predicate<Musician> musicianPredicate = new MusicianInBandPredicate(filteredBands.get(0));

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.AMY;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.AMY;
 
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;

--- a/src/test/java/seedu/address/logic/commands/AddBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddBandCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBands.ACE;
+import static seedu.address.testutil.typicalentities.TypicalBands.ACE;
 
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
 
 import java.nio.file.Path;
 import java.util.ArrayList;

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_MUSICIAN;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -8,7 +8,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_MUSICIAN;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_MUSICIAN;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_MUSICIAN;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
@@ -3,15 +3,34 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_MUSICIANS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getOneBandAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalBands.ACE;
+import static seedu.address.testutil.typicalentities.TypicalBands.BOOM;
+import static seedu.address.testutil.typicalentities.TypicalBands.CANDY;
+import static seedu.address.testutil.typicalentities.TypicalBands.DRAGON;
+import static seedu.address.testutil.typicalentities.TypicalBands.ELISE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BENSON;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.CARL;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.DANIEL;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.FIONA;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.GEORGE;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.band.BandNameContainsKeywordsPredicate;
+
 
 class FindBandCommandTest {
 
@@ -19,33 +38,59 @@ class FindBandCommandTest {
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     @Test
     void execute_validBandNameNoMusician_success() {
-        // expected
+        String expectedMessage = String.format(MESSAGE_MUSICIANS_LISTED_OVERVIEW, 0);
+        BandNameContainsKeywordsPredicate predicate = new BandNameContainsKeywordsPredicate("ACE JAZZ");
+        expectedModel.updateFilteredBandMusicianList(predicate);
 
-        FindBandCommand command = new FindBandCommand(new BandNameContainsKeywordsPredicate("ACE"));
-
-//        String expectedMessage = String.format(MESSAGE_MUSICIANS_LISTED_OVERVIEW, 3);
-//        NameContainsKeywordsPredicate predicate = prepareNameKeywordsPredicate("Kurz Elle Kunz");
-//
-//        HashSet<Predicate<Musician>> predicates = new HashSet<>(Arrays.asList(predicate));
-//        FindCommand command = new FindCommand(predicates);
-//        expectedModel.updateFilteredMusicianList(predicate);
-//        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-//        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredMusicianList());
+        FindBandCommand command = new FindBandCommand(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(), model.getFilteredMusicianList());
+        assertEquals(Arrays.asList(ACE), model.getFilteredBandList());
     }
 
     @Test
     void execute_validBandNameHasMusician_success() {
+        String expectedMessage = String.format(MESSAGE_MUSICIANS_LISTED_OVERVIEW, 2);
+        BandNameContainsKeywordsPredicate predicate = new BandNameContainsKeywordsPredicate("dragon metal");
+        expectedModel.updateFilteredBandMusicianList(predicate);
 
+        FindBandCommand command = new FindBandCommand(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, DANIEL), model.getFilteredMusicianList());
+        assertEquals(Arrays.asList(DRAGON), model.getFilteredBandList());
     }
 
     @Test
-    void execute_invalidBandNameListLengthOne_exceptionThrown() {
+    void execute_invalidBandNameListLengthOne_throwsCommandException() {
+        // Reset model and expectedModel to contain only one band
+        model = new ModelManager(getOneBandAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getOneBandAddressBook(), new UserPrefs());
 
+        // unit test
+        BandNameContainsKeywordsPredicate predicate = new BandNameContainsKeywordsPredicate("Black Pink");
+        expectedModel.updateFilteredBandMusicianList(predicate);
+
+        FindBandCommand command = new FindBandCommand(predicate);
+        assertCommandFailure(command, model, Messages.MESSAGE_UNKNOWN_BAND);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE),
+                model.getFilteredMusicianList());
+        assertEquals(Arrays.asList(DRAGON), model.getFilteredBandList());
+
+        // Reset model and expectedModel back for other tests
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     }
 
     @Test
-    void execute_invalidBandNameListLengthLong_exceptionThrown() {
+    void execute_invalidBandNameListLengthMoreThanOne_throwsCommandException() {
+        BandNameContainsKeywordsPredicate predicate = new BandNameContainsKeywordsPredicate("Meowmeow");
+        expectedModel.updateFilteredBandMusicianList(predicate);
 
+        FindBandCommand command = new FindBandCommand(predicate);
+        assertCommandFailure(command, model, Messages.MESSAGE_UNKNOWN_BAND);
+        assertEquals(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE),
+                model.getFilteredMusicianList());
+        assertEquals(Arrays.asList(ACE, BOOM, CANDY, DRAGON, ELISE), model.getFilteredBandList());
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
@@ -3,7 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,9 +18,37 @@ class FindBandCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     @Test
-    void execute() {
+    void execute_validBandNameNoMusician_success() {
+        // expected
+
+        FindBandCommand command = new FindBandCommand(new BandNameContainsKeywordsPredicate("ACE"));
+
+//        String expectedMessage = String.format(MESSAGE_MUSICIANS_LISTED_OVERVIEW, 3);
+//        NameContainsKeywordsPredicate predicate = prepareNameKeywordsPredicate("Kurz Elle Kunz");
+//
+//        HashSet<Predicate<Musician>> predicates = new HashSet<>(Arrays.asList(predicate));
+//        FindCommand command = new FindCommand(predicates);
+//        expectedModel.updateFilteredMusicianList(predicate);
+//        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+//        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredMusicianList());
+    }
+
+    @Test
+    void execute_validBandNameHasMusician_success() {
 
     }
+
+    @Test
+    void execute_invalidBandNameListLengthOne_exceptionThrown() {
+
+    }
+
+    @Test
+    void execute_invalidBandNameListLengthLong_exceptionThrown() {
+
+    }
+
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,11 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_MUSICIANS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalMusicians.BENSON;
-import static seedu.address.testutil.TypicalMusicians.CARL;
-import static seedu.address.testutil.TypicalMusicians.ELLE;
-import static seedu.address.testutil.TypicalMusicians.FIONA;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BENSON;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.CARL;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.FIONA;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,11 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_MUSICIANS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.BENSON;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.CARL;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.FIONA;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showMusicianAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_MUSICIAN;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -25,8 +25,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalMusicians.AMY;
-import static seedu.address.testutil.TypicalMusicians.BOB;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.AMY;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BOB;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MUSICIANS;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.BENSON;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BENSON;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/src/test/java/seedu/address/model/band/BandTest.java
+++ b/src/test/java/seedu/address/model/band/BandTest.java
@@ -2,7 +2,7 @@ package seedu.address.model.band;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBands.ACE;
+import static seedu.address.testutil.typicalentities.TypicalBands.ACE;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalBands.ACE;
-import static seedu.address.testutil.TypicalBands.BOOM;
-import static seedu.address.testutil.TypicalBands.CANDY;
-import static seedu.address.testutil.TypicalBands.ELISE;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.ELLE;
+import static seedu.address.testutil.typicalentities.TypicalBands.ACE;
+import static seedu.address.testutil.typicalentities.TypicalBands.BOOM;
+import static seedu.address.testutil.typicalentities.TypicalBands.CANDY;
+import static seedu.address.testutil.typicalentities.TypicalBands.ELISE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/model/musician/MusicianTest.java
+++ b/src/test/java/seedu/address/model/musician/MusicianTest.java
@@ -8,8 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.BOB;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BOB;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/musician/UniqueMusicianListTest.java
+++ b/src/test/java/seedu/address/model/musician/UniqueMusicianListTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.BOB;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BOB;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/storage/JsonAdaptedMusicianTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMusicianTest.java
@@ -3,7 +3,7 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedMusician.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.BENSON;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BENSON;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -3,10 +3,10 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.HOON;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.IDA;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonAddressBookStorageTest.java
@@ -3,10 +3,10 @@ package seedu.address.storage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.HOON;
-import static seedu.address.testutil.TypicalMusicians.IDA;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.HOON;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.IDA;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.typicalentities.TypicalMusicians;
 
 public class JsonSerializableAddressBookTest {
 
@@ -25,7 +25,7 @@ public class JsonSerializableAddressBookTest {
         JsonSerializableAddressBook dataFromFile = JsonUtil.readJsonFile(TYPICAL_MUSICIANS_FILE,
                 JsonSerializableAddressBook.class).get();
         AddressBook addressBookFromFile = dataFromFile.toModelType();
-        AddressBook typicalMusiciansAddressBook = TypicalMusicians.getTypicalAddressBook();
+        AddressBook typicalMusiciansAddressBook = getTypicalAddressBook();
         assertEquals(addressBookFromFile, typicalMusiciansAddressBook);
     }
 

--- a/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
+++ b/src/test/java/seedu/address/storage/JsonSerializableAddressBookTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.JsonUtil;
 import seedu.address.model.AddressBook;
-import seedu.address.testutil.TypicalMusicians;
+import seedu.address.testutil.typicalentities.TypicalMusicians;
 
 public class JsonSerializableAddressBookTest {
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 
 import java.nio.file.Path;
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,7 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static seedu.address.testutil.TypicalMusicians.getTypicalAddressBook;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.getTypicalAddressBook;
 
 import java.nio.file.Path;
 

--- a/src/test/java/seedu/address/testutil/typicalentities/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/typicalentities/TypicalAddressBook.java
@@ -1,5 +1,7 @@
 package seedu.address.testutil.typicalentities;
 
+import static seedu.address.testutil.typicalentities.TypicalBands.DRAGON;
+
 import seedu.address.model.AddressBook;
 import seedu.address.model.band.Band;
 import seedu.address.model.musician.Musician;
@@ -21,6 +23,18 @@ public class TypicalAddressBook {
         for (Band band : TypicalBands.getTypicalBands()) {
             ab.addBand(band);
         }
+        return ab;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical musicians and only one band.
+     */
+    public static AddressBook getOneBandAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Musician musician : TypicalMusicians.getTypicalMusicians()) {
+            ab.addMusician(musician);
+        }
+        ab.addBand(DRAGON);
         return ab;
     }
 }

--- a/src/test/java/seedu/address/testutil/typicalentities/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/typicalentities/TypicalAddressBook.java
@@ -1,0 +1,26 @@
+package seedu.address.testutil.typicalentities;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.band.Band;
+import seedu.address.model.musician.Musician;
+
+/**
+ * A utility class to create a typical address book with the typical musicians and bands to be used in tests.
+ */
+public class TypicalAddressBook {
+    private TypicalAddressBook() {} // prevents instantiation
+
+    /**
+     * Returns an {@code AddressBook} with all the typical musicians and bands.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Musician musician : TypicalMusicians.getTypicalMusicians()) {
+            ab.addMusician(musician);
+        }
+        for (Band band : TypicalBands.getTypicalBands()) {
+            ab.addBand(band);
+        }
+        return ab;
+    }
+}

--- a/src/test/java/seedu/address/testutil/typicalentities/TypicalBands.java
+++ b/src/test/java/seedu/address/testutil/typicalentities/TypicalBands.java
@@ -1,16 +1,17 @@
-package seedu.address.testutil;
+package seedu.address.testutil.typicalentities;
 
-import static seedu.address.testutil.TypicalMusicians.ALICE;
-import static seedu.address.testutil.TypicalMusicians.BOB;
-import static seedu.address.testutil.TypicalMusicians.CARL;
-import static seedu.address.testutil.TypicalMusicians.DANIEL;
-import static seedu.address.testutil.TypicalMusicians.ELLE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BOB;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.CARL;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.DANIEL;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.band.Band;
+import seedu.address.testutil.BandBuilder;
 
 
 /**

--- a/src/test/java/seedu/address/testutil/typicalentities/TypicalMusicians.java
+++ b/src/test/java/seedu/address/testutil/typicalentities/TypicalMusicians.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.musician.Musician;
 import seedu.address.testutil.MusicianBuilder;
 

--- a/src/test/java/seedu/address/testutil/typicalentities/TypicalMusicians.java
+++ b/src/test/java/seedu/address/testutil/typicalentities/TypicalMusicians.java
@@ -1,4 +1,4 @@
-package seedu.address.testutil;
+package seedu.address.testutil.typicalentities;
 
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
@@ -16,6 +16,7 @@ import java.util.List;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.musician.Musician;
+import seedu.address.testutil.MusicianBuilder;
 
 /**
  * A utility class containing a list of {@code Musician} objects to be used in tests.
@@ -58,17 +59,6 @@ public class TypicalMusicians {
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalMusicians() {} // prevents instantiation
-
-    /**
-     * Returns an {@code AddressBook} with all the typical persons.
-     */
-    public static AddressBook getTypicalAddressBook() {
-        AddressBook ab = new AddressBook();
-        for (Musician musician : getTypicalMusicians()) {
-            ab.addMusician(musician);
-        }
-        return ab;
-    }
 
     public static List<Musician> getTypicalMusicians() {
         return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));


### PR DESCRIPTION
`findb BANDNAME` lists band members in a band. In this PR, I have:
1. Complete unit tests for band name (testcases written based on white-box testing)
2. Extracted `getTypicalAddressBook()` from `TypicalMusicians` class to a separate class called `TypicalAddressBook` class. Refactored the relevant files into a subpackage `/typicalentities` under `/testutil`. The main goal of this refactoring is for us to use a model address book that contains both musicians and bands, instead of only the musicians as per AB3.