### PR TITLE
Fix edit/delete command to include band list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/band/FindBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/band/FindBandCommand.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.band;
 
 import static java.util.Objects.requireNonNull;
 
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.band.Band;

--- a/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
@@ -56,6 +56,7 @@ public class AddCommand extends Command {
         }
 
         model.addMusician(toAdd);
+        model.updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
@@ -56,7 +56,6 @@ public class AddCommand extends Command {
         }
 
         model.addMusician(toAdd);
-        model.updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/DeleteCommand.java
@@ -44,6 +44,8 @@ public class DeleteCommand extends Command {
 
         Musician musicianToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteMusician(musicianToDelete);
+        model.updateFilteredMusicianList(Model.PREDICATE_SHOW_ALL_MUSICIANS);
+        model.updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(String.format(MESSAGE_DELETE_MUSICIAN_SUCCESS, Messages.format(musicianToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/DeleteCommand.java
@@ -44,8 +44,7 @@ public class DeleteCommand extends Command {
 
         Musician musicianToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteMusician(musicianToDelete);
-        model.updateFilteredMusicianList(Model.PREDICATE_SHOW_ALL_MUSICIANS);
-        model.updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
+
         return new CommandResult(String.format(MESSAGE_DELETE_MUSICIAN_SUCCESS, Messages.format(musicianToDelete)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
@@ -83,10 +83,9 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_MUSICIAN);
         }
 
+        // update musician list to show all, update band list to show all, update bands musicians
         model.setMusician(musicianToEdit, editedMusician);
 
-        model.updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
-        model.updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(String.format(MESSAGE_EDIT_MUSICIAN_SUCCESS, Messages.format(editedMusician)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BANDS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MUSICIANS;
 
 import java.util.Collections;
@@ -83,7 +84,9 @@ public class EditCommand extends Command {
         }
 
         model.setMusician(musicianToEdit, editedMusician);
+
         model.updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
+        model.updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(String.format(MESSAGE_EDIT_MUSICIAN_SUCCESS, Messages.format(editedMusician)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
@@ -5,8 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BANDS;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MUSICIANS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/musician/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/FindCommand.java
@@ -53,6 +53,7 @@ public class FindCommand extends Command {
         // since it will always be overridden by the first predicate.
         Predicate<Musician> combinedPredicate = predicates.stream().reduce(x -> true, Predicate::and);
         model.updateFilteredMusicianList(combinedPredicate);
+        model.updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
         return new CommandResult(
                 String.format(Messages.MESSAGE_MUSICIANS_LISTED_OVERVIEW, model.getFilteredMusicianList().size()));
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.FindBandCommand;
+import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.logic.commands.band.AddBandCommand;
 import seedu.address.logic.commands.band.AddMusiciantoBandCommand;
 import seedu.address.logic.commands.band.DeleteBandCommand;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,10 +9,10 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.logic.commands.band.AddBandCommand;
 import seedu.address.logic.commands.band.AddMusiciantoBandCommand;
 import seedu.address.logic.commands.band.DeleteBandCommand;
+import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.logic.commands.general.ClearCommand;
 import seedu.address.logic.commands.general.ExitCommand;
 import seedu.address.logic.commands.general.HelpCommand;

--- a/src/main/java/seedu/address/logic/parser/FindBandCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindBandCommandParser.java
@@ -4,7 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.function.Predicate;
 
-import seedu.address.logic.commands.FindBandCommand;
+import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.band.Band;
 import seedu.address.model.band.BandName;

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -91,7 +91,6 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setMusician(Musician target, Musician editedMusician) {
         requireNonNull(editedMusician);
-
         musicians.setMusician(target, editedMusician);
     }
 
@@ -125,6 +124,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean hasMusicianInBand(int bandIndex, Musician musician) {
         requireNonNull(musician);
         return bands.hasMusician(bandIndex, musician);
+    }
+
+    /**
+     * For all bands, remove target and replace with editedMusician. If editedMusician is null, just remove target.
+     */
+    public void updateMusicianInAllBands(Musician target, Musician editedMusician) {
+        requireNonNull(target);
+        bands.updateMusicianInAllBands(target, editedMusician);
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -114,10 +114,6 @@ public class ModelManager implements Model {
         updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
     }
 
-    /**
-     * This method is used by edit and delete musician commands to simultaneously update the
-     * corresponding musician in band list.
-     */
     @Override
     public void setMusician(Musician target, Musician editedMusician) {
         requireAllNonNull(target, editedMusician);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -100,6 +100,11 @@ public class ModelManager implements Model {
     @Override
     public void deleteMusician(Musician target) {
         addressBook.removeMusician(target);
+
+        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
+        updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
+
+        updateMusicianInAllBands(target, null);
     }
 
     @Override
@@ -112,6 +117,20 @@ public class ModelManager implements Model {
     public void setMusician(Musician target, Musician editedMusician) {
         requireAllNonNull(target, editedMusician);
         addressBook.setMusician(target, editedMusician);
+
+        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
+        updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
+
+        updateMusicianInAllBands(target, editedMusician);
+    }
+
+    /**
+     * This method is used by edit and delete musician commands to simultaneously update the
+     * corresponding musician in band list.
+     */
+    private void updateMusicianInAllBands(Musician target, Musician editedMusician) {
+        requireNonNull(target);
+        addressBook.updateMusicianInAllBands(target, editedMusician);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,8 +111,13 @@ public class ModelManager implements Model {
     public void addMusician(Musician musician) {
         addressBook.addMusician(musician);
         updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
+        updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
     }
 
+    /**
+     * This method is used by edit and delete musician commands to simultaneously update the
+     * corresponding musician in band list.
+     */
     @Override
     public void setMusician(Musician target, Musician editedMusician) {
         requireAllNonNull(target, editedMusician);
@@ -125,7 +130,7 @@ public class ModelManager implements Model {
     }
 
     /**
-     * This method is used by edit and delete musician commands to simultaneously update the
+     * Used by edit and delete musician commands to simultaneously update the
      * corresponding musician in band list.
      */
     private void updateMusicianInAllBands(Musician target, Musician editedMusician) {

--- a/src/main/java/seedu/address/model/band/Band.java
+++ b/src/main/java/seedu/address/model/band/Band.java
@@ -48,6 +48,17 @@ public class Band {
     public boolean hasMusician(Musician musician) {
         return musicians.contains(musician);
     }
+
+    public void setMusician(Musician target, Musician editedMusician) {
+        if (musicians.contains(target)) {
+            musicians.remove(target);
+        }
+
+        if (editedMusician != null) {
+            musicians.add(editedMusician);
+        }
+    }
+
     /**
      * Returns true if both bands have the same name.
      * This defines a weaker notion of equality between two persons.

--- a/src/main/java/seedu/address/model/band/BandMusicians.java
+++ b/src/main/java/seedu/address/model/band/BandMusicians.java
@@ -17,6 +17,16 @@ public class BandMusicians {
         this.musicians = musicians;
     }
 
+    public void setMusician(Musician target, Musician editedMusician) {
+        if (musicians.contains(target)) {
+            musicians.remove(target);
+        }
+
+        if (editedMusician != null) {
+            musicians.add(editedMusician);
+        }
+    }
+
     @Override
     public String toString() {
         return musicians.toString();

--- a/src/main/java/seedu/address/model/band/UniqueBandList.java
+++ b/src/main/java/seedu/address/model/band/UniqueBandList.java
@@ -70,6 +70,26 @@ public class UniqueBandList implements Iterable<Band> {
         }
     }
 
+    /**
+     * Replaces the band {@code target} in the list with {@code editedMusician}.
+     * {@code target} must exist in the list.
+     * The band identity of {@code editedBand} must not be the same as another existing band in the list.
+     */
+    public void setBand(Band target, Band editedBand) {
+        requireAllNonNull(target, editedBand);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new BandNotFoundException();
+        }
+
+        if (!target.isSameBand(editedBand) && contains(editedBand)) {
+            throw new DuplicateBandException();
+        }
+
+        internalList.set(index, editedBand);
+    }
+
     public void setBand(UniqueBandList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);

--- a/src/main/java/seedu/address/model/band/UniqueBandList.java
+++ b/src/main/java/seedu/address/model/band/UniqueBandList.java
@@ -58,29 +58,23 @@ public class UniqueBandList implements Iterable<Band> {
         requireNonNull(index);
         return internalList.get(index.getZeroBased());
     }
+
     /**
-     * Replaces the band {@code target} in the list with {@code editedMusician}.
-     * {@code target} must exist in the list.
-     * The band identity of {@code editedBand} must not be the same as another existing band in the list.
+     * Replaces musician {@code target} in every band she is in with {@code editedMusician}.
      */
-    public void setBand(Band target, Band editedBand) {
-        requireAllNonNull(target, editedBand);
+    public void updateMusicianInAllBands(Musician target, Musician editedMusician) {
+        requireNonNull(target);
 
-        int index = internalList.indexOf(target);
-        if (index == -1) {
-            throw new BandNotFoundException();
+        for (int i = 0; i < internalList.size(); i++) {
+            internalList.get(i).setMusician(target, editedMusician);
         }
-
-        if (!target.isSameBand(editedBand) && contains(editedBand)) {
-            throw new DuplicateBandException();
-        }
-
-        internalList.set(index, editedBand);
     }
+
     public void setBand(UniqueBandList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
     }
+
     /**
      * Replaces the contents of this list with {@code musicians}.
      * {@code musicians} must not contain duplicate musicians.

--- a/src/main/java/seedu/address/model/musician/UniqueMusicianList.java
+++ b/src/main/java/seedu/address/model/musician/UniqueMusicianList.java
@@ -56,6 +56,7 @@ public class UniqueMusicianList implements Iterable<Musician> {
         requireNonNull(index);
         return internalList.get(index.getZeroBased());
     }
+
     /**
      * Replaces the musician {@code target} in the list with {@code editedMusician}.
      * {@code target} must exist in the list.

--- a/src/test/java/seedu/address/logic/commands/AddMusiciantoBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMusiciantoBandCommandTest.java
@@ -158,12 +158,12 @@ public class AddMusiciantoBandCommandTest {
         }
 
         @Override
-        public void updateFilteredMusicianList(Predicate<Musician> predicate) {
+        public void updateFilteredBandList(Predicate<Band> band) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void updateFilteredBandList(Predicate<Band> predicate) {
+        public void updateFilteredMusicianList(Predicate<Musician> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -242,6 +242,9 @@ public class AddMusiciantoBandCommandTest {
         @Override
         public ObservableList<Band> getFilteredBandList() {
             return new FilteredList<>(bandsAdded.asUnmodifiableObservableList());
+        }
+        @Override
+        public void updateFilteredBandList(Predicate<Band> predicate) {
         }
         @Override
         public ObservableList<Musician> getFilteredMusicianList() {

--- a/src/test/java/seedu/address/logic/commands/AddMusiciantoBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMusiciantoBandCommandTest.java
@@ -158,12 +158,12 @@ public class AddMusiciantoBandCommandTest {
         }
 
         @Override
-        public void updateFilteredBandList(Predicate<Band> band) {
+        public void updateFilteredMusicianList(Predicate<Musician> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void updateFilteredMusicianList(Predicate<Musician> predicate) {
+        public void updateFilteredBandList(Predicate<Band> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindBandCommandTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/musician/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/musician/DeleteCommandTest.java
@@ -61,7 +61,6 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteMusician(musicianToDelete);
-        showNoMusician(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -154,7 +154,7 @@ public class UniqueBandListTest {
     @Test
     public void hasMusician_musicianNotInBand_returnsFalse() {
         uniqueBandList.add(ELISE);
-        assertFalse(uniqueBandList.hasMusician(0, ALICE));
+        assertFalse(uniqueBandList.hasMusician(0, BOB));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.typicalentities.TypicalBands.BOOM;
 import static seedu.address.testutil.typicalentities.TypicalBands.CANDY;
 import static seedu.address.testutil.typicalentities.TypicalBands.ELISE;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.ALICE;
+import static seedu.address.testutil.typicalentities.TypicalMusicians.BOB;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.ELLE;
 
 import java.util.Arrays;
@@ -141,7 +142,7 @@ public class UniqueBandListTest {
     @Test
     public void hasMusician_bandWithoutMusicians_returnsFalse() {
         uniqueBandList.add(ACE);
-        assertFalse(uniqueBandList.hasMusician(0, ALICE));
+        assertFalse(uniqueBandList.hasMusician(0, BOB));
     }
 
     @Test


### PR DESCRIPTION
This PR contains the necessary fixes so that edits/deletes made to the musician is promptly reflected in all bands that the musician belongs to.

**Rationale:**
Currently, operations on musicians are not synced to the bands since 
1. Bands do not store a reference to the musician
2. Editing a musician involves deleting the old object and insert a new object, deleting a musicians involves deleting the old object.

Due to the above reasons, there is a need to separately update the band list (loop over all bands and edit/delete the corresponding musician) while doing edit/delete operation for musician.

**Implementation:**
- In `ModelManager`, both `filteredmusicians` and `filteredbands` are set to display all musicians/bands. This is to ensure deterministic and consistent behaviours for UI. 
- In `ModelManager`, a `updateMusicianInAllBands(Musician target, Musician editedMusician)` is created to loop through all bands and do the changes.