### PR TITLE
Fix Edit Musician Bug

### DIFF
--- a/src/main/java/seedu/address/model/band/UniqueBandList.java
+++ b/src/main/java/seedu/address/model/band/UniqueBandList.java
@@ -66,7 +66,9 @@ public class UniqueBandList implements Iterable<Band> {
         requireNonNull(target);
 
         for (int i = 0; i < internalList.size(); i++) {
-            internalList.get(i).setMusician(target, editedMusician);
+            if (internalList.get(i).hasMusician(target)) {
+                internalList.get(i).setMusician(target, editedMusician);
+            }
         }
     }
 


### PR DESCRIPTION
There was a bug in the edit musician method which resulted in the new musician being added to all bands stored in the addressbook regardless of if they were there beforehand.

This bug has been fixed to only store the edited musician if they already existed in a particular band prior to the edit.