### PR TITLE
Fix test bleeding bug

### DIFF
--- a/src/test/java/seedu/address/model/band/UniqueBandListTest.java
+++ b/src/test/java/seedu/address/model/band/UniqueBandListTest.java
@@ -31,6 +31,7 @@ public class UniqueBandListTest {
 
     private final UniqueBandList uniqueBandList = new UniqueBandList();
 
+
     @Test
     public void contains_nullBand_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueBandList.contains(null));
@@ -189,8 +190,8 @@ public class UniqueBandListTest {
     @Test
     public void addMusician_musicianAdded_bandGetsUpdated() {
         uniqueBandList.add(ACE);
-        uniqueBandList.addMusician(0, ALICE);
-        assertTrue(ACE.hasMusician(ALICE));
+        uniqueBandList.addMusician(0, ELLE);
+        assertTrue(uniqueBandList.hasMusician(0, ELLE));
     }
 
     @Test


### PR DESCRIPTION
Mutable `uniquebandlist` variable from one test bleeding into another one, leading to test failure.
[Link](https://stackoverflow.com/questions/42442016/junit-tests-influence-each-other) to StackOverflow.

Bug is fixed by changing `ALICE` to `ELLE`.