### PR TITLE
Enhancement to the "add musician to band" feature 

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -63,6 +63,11 @@ public class Index {
     }
 
     @Override
+    public int hashCode() {
+        return zeroBasedIndex;
+    }
+
+    @Override
     public String toString() {
         return new ToStringBuilder(this).add("zeroBasedIndex", zeroBasedIndex).toString();
     }

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,5 +1,6 @@
 package seedu.address.logic;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -7,6 +8,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.band.Band;
 import seedu.address.model.musician.Musician;
+import seedu.address.model.musician.Name;
 
 /**
  * Container for user visible messages.
@@ -68,6 +70,19 @@ public class Messages {
                 .append(band.getName())
                 .append("; Musician Name: ")
                 .append(musician.getName());
+        return builder.toString();
+    }
+
+    /**
+     * Formats the {@code band} for display to the user.
+     */
+    public static String format(Band band, List<Musician> musicians) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Band Name: ")
+                .append(band.getName())
+                .append("; Musician Names: ")
+                .append(musicians.stream().map(Musician::getName)
+                        .map(Name::toString).collect(Collectors.joining(", ")));
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/band/AddMusicianToBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/band/AddMusicianToBandCommand.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.band.Band;
+import seedu.address.model.band.BandNameContainsKeywordsPredicate;
 import seedu.address.model.musician.Musician;
 
 /**
@@ -64,6 +65,10 @@ public class AddMusicianToBandCommand extends Command {
         Band band = lastShownBandList.get(bandToAddInto.getZeroBased());
         Musician musician = lastShownMusicianList.get(musicianToAdd.getZeroBased());
         model.addMusicianToBand(bandToAddInto.getZeroBased(), musicianToAdd.getZeroBased());
+
+        // update the filtered band list to show ONLY the band that the musician is added to and
+        // update the filtered musician list to show ONLY the members in the band
+        model.updateFilteredBandMusicianList(new BandNameContainsKeywordsPredicate(band.getName().toString()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(band, musician)));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.musician.ListCommand;
 import seedu.address.logic.parser.band.AddBandCommandParser;
 import seedu.address.logic.parser.band.AddMusicianToBandCommandParser;
 import seedu.address.logic.parser.band.DeleteBandCommandParser;
+import seedu.address.logic.parser.band.FindBandCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.musician.AddCommandParser;
 import seedu.address.logic.parser.musician.DeleteCommandParser;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,7 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_INSTRUMENT = new Prefix("i/");
     public static final Prefix PREFIX_GENRE = new Prefix("g/");
-    public static final Prefix PREFIX_BINDEX = new Prefix("bin/");
-    public static final Prefix PREFIX_MINDEX = new Prefix("min/");
+    public static final Prefix PREFIX_BINDEX = new Prefix("b/");
+    public static final Prefix PREFIX_MINDEX = new Prefix("m/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/band/AddMusicianToBandCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/band/AddMusicianToBandCommandParser.java
@@ -4,6 +4,8 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_BINDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MINDEX;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
@@ -33,8 +35,11 @@ public class AddMusicianToBandCommandParser implements Parser<AddMusicianToBandC
         }
         try {
             Index bandIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_BINDEX).get());
-            Index musicianIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_MINDEX).get());
-            return new AddMusicianToBandCommand(bandIndex, musicianIndex);
+            List<Index> musicianIndices = new ArrayList<>();
+            for (String indexString : argMultimap.getAllValues(PREFIX_MINDEX)) {
+                musicianIndices.add(ParserUtil.parseIndex(indexString));
+            }
+            return new AddMusicianToBandCommand(bandIndex, musicianIndices);
         } catch (ParseException pe) {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMusicianToBandCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/band/FindBandCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/band/FindBandCommandParser.java
@@ -1,10 +1,12 @@
-package seedu.address.logic.parser;
+package seedu.address.logic.parser.band;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.function.Predicate;
 
 import seedu.address.logic.commands.band.FindBandCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.band.Band;
 import seedu.address.model.band.BandName;

--- a/src/test/java/seedu/address/logic/commands/AddMusicianToBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMusicianToBandCommandTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -38,8 +40,8 @@ public class AddMusicianToBandCommandTest {
     }
     @Test
     public void constructor_nullBand_throwsNullPointerException() {
-        Index musicianIndex = Index.fromOneBased(1);
-        assertThrows(NullPointerException.class, () -> new AddMusicianToBandCommand(null, musicianIndex));
+        List<Index> musicianIndices = List.of(Index.fromOneBased(1));
+        assertThrows(NullPointerException.class, () -> new AddMusicianToBandCommand(null, musicianIndices));
     }
     @Test
     public void constructor_nullBandAndMusician_throwsNullPointerException() {
@@ -55,13 +57,15 @@ public class AddMusicianToBandCommandTest {
         CommandResult addCommandResult = new AddCommand(validMusician).execute(modelBandStub);
         CommandResult addBandCommandResult = new AddBandCommand(validBand).execute(modelBandStub);
         Index bandIndex = Index.fromOneBased(1);
-        Index musicianIndex = Index.fromOneBased(1);
-        CommandResult commandResult = new AddMusicianToBandCommand(bandIndex, musicianIndex).execute(modelBandStub);
+        List<Index> musicianIndices = List.of(Index.fromOneBased(1));
+        CommandResult commandResult = new AddMusicianToBandCommand(bandIndex, musicianIndices).execute(modelBandStub);
 
-        assertEquals(String.format(AddMusicianToBandCommand.MESSAGE_SUCCESS,
-                        Messages.format(modelBandStub.bandsAdded.get(bandIndex),
-                                modelBandStub.musiciansAdded.get(musicianIndex))),
-                commandResult.getFeedbackToUser());
+        String expectedSuccessMessage = String.format(
+                AddMusicianToBandCommand.MESSAGE_SUCCESS,
+                Messages.format(modelBandStub.bandsAdded.get(bandIndex),
+                        musicianIndices.stream().map(modelBandStub.musiciansAdded::get).collect(Collectors.toList()))
+        );
+        assertEquals(expectedSuccessMessage, commandResult.getFeedbackToUser());
         assertEquals(validBand, modelBandStub.bandsAdded.get(bandIndex));
         assertEquals(validBand.getMusicians(), modelBandStub.bandsAdded.get(bandIndex).getMusicians());
     }
@@ -75,13 +79,13 @@ public class AddMusicianToBandCommandTest {
         CommandResult addCommandResult = new AddCommand(validMusician).execute(modelBandStub);
         CommandResult addBandCommandResult = new AddBandCommand(validBand).execute(modelBandStub);
         Index bandIndex = Index.fromOneBased(1);
-        Index musicianIndex = Index.fromOneBased(1);
+        List<Index> musicianIndices = List.of(Index.fromOneBased(1));
         CommandResult firstAddMusiciancommandResult =
-                new AddMusicianToBandCommand(bandIndex, musicianIndex).execute(modelBandStub);
+                new AddMusicianToBandCommand(bandIndex, musicianIndices).execute(modelBandStub);
 
         assertThrows(CommandException.class,
                 AddMusicianToBandCommand.MESSAGE_DUPLICATE_MUSICIAN, () ->
-                        new AddMusicianToBandCommand(bandIndex, musicianIndex).execute(modelBandStub));
+                        new AddMusicianToBandCommand(bandIndex, musicianIndices).execute(modelBandStub));
     }
     /**
      * A default model stub that have all of the methods failing.
@@ -245,6 +249,9 @@ public class AddMusicianToBandCommandTest {
         }
         @Override
         public void updateFilteredBandList(Predicate<Band> predicate) {
+        }
+        @Override
+        public void updateFilteredBandMusicianList(Predicate<Band> predicate) {
         }
         @Override
         public ObservableList<Musician> getFilteredMusicianList() {


### PR DESCRIPTION
In this PR, the following are done:
- [x] Modify the GUI so that when `addm` is executed, the GUI band panel reflect ONLY the band the musician is added to, and the GUI musician panel reflect ONLY the members in that band
- [x] Change the command format from `addm [bin/BAND_INDEX] [min/MUSICIAN_INDEX]" to `addm [b/BAND_INDEX] [m/MUSICIAN_INDEX]` for simplicity
- [x] Enhance the `addm` feature by allowing multiple musicians to be added in a single command, e.g. `addm b/1 m/1 m/2 m/4` and ensure "all or nothing" behaviour (either all musicians added or none of them is added)
- [x] Handle exceptions when the user input a musician index repeatedly, e.g. `addm b/1 m/1 m/1` and ensure none of the musicians are added.