### PR TITLE
Modify the GUI behaviour after certain commands to minimise confusion

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -100,28 +100,21 @@ public class ModelManager implements Model {
     @Override
     public void deleteMusician(Musician target) {
         addressBook.removeMusician(target);
-
-        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
-        updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
-
+        setToDefaultGui();
         updateMusicianInAllBands(target, null);
     }
 
     @Override
     public void addMusician(Musician musician) {
         addressBook.addMusician(musician);
-        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
-        updateFilteredBandList(Model.PREDICATE_SHOW_ALL_BANDS);
+        setToDefaultGui();
     }
 
     @Override
     public void setMusician(Musician target, Musician editedMusician) {
         requireAllNonNull(target, editedMusician);
         addressBook.setMusician(target, editedMusician);
-
-        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
-        updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
-
+        setToDefaultGui();
         updateMusicianInAllBands(target, editedMusician);
     }
 
@@ -144,6 +137,7 @@ public class ModelManager implements Model {
     public void addBand(Band band) {
         requireAllNonNull(band);
         addressBook.addBand(band);
+        setToDefaultGui();
     }
 
     @Override
@@ -163,6 +157,7 @@ public class ModelManager implements Model {
     @Override
     public void deleteBand(Band target) {
         addressBook.removeBand(target);
+        setToDefaultGui();
     }
 
     //=========== Filtered Musician List Accessors =============================================================
@@ -200,9 +195,8 @@ public class ModelManager implements Model {
     }
 
     /**
-     * Returns an unmodifiable view of the list of {@code Band} backed by the internal list of
-     * {@code versionedAddressBook}. Returns an unmodifiable view of the list of {@code Musician}
-     * backed by the internal list of {@code versionedAddressBook}
+     * Updates the filtered band list to show only the band with the corresponding predicate and
+     * updates the filtered musician list to show only the members in the band.
      * If there is no band with the corresponding name, an error message will be displayed
      * And the panel will show initial state of listing all.
      */
@@ -218,6 +212,15 @@ public class ModelManager implements Model {
 
         Predicate<Musician> musicianPredicate = new MusicianInBandPredicate(filteredBands.get(0));
         filteredMusicians.setPredicate(musicianPredicate);
+    }
+
+    /**
+     * Update the filtered band list to show all bands and the filtered musician list to show all musicians.
+     * This is the default state of the GUI and the result of the list command.
+     */
+    private void setToDefaultGui() {
+        updateFilteredMusicianList(PREDICATE_SHOW_ALL_MUSICIANS);
+        updateFilteredBandList(PREDICATE_SHOW_ALL_BANDS);
     }
 
     @Override
@@ -238,3 +241,4 @@ public class ModelManager implements Model {
     }
 
 }
+


### PR DESCRIPTION
This PR modify the GUI to make its behaviour after certain commands less confusing.

The _default behaviour_ for the GUI musician panel and band panel is to list all musicians and to list all bands.

The GUI now behaves as such:
- For musicians: after add, edit, delete, and find commands, the GUI updates the musician panel, while the band panel falls back to default behaviour.
- For bands: 
    - after `addb` and `deleteb`, the GUI updates the band panel, while the musician panel falls back to default behaviour.
    - after `findb` and `addm`, the GUI updates both the band panel and the musician panel to reflect the corresponding band and the members in the band
