### PR TITLE
Overwrite equals method for several classes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/band/AddMusicianToBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/band/AddMusicianToBandCommand.java
@@ -88,4 +88,19 @@ public class AddMusicianToBandCommand extends Command {
         model.updateFilteredBandMusicianList(new BandNameContainsKeywordsPredicate(band.getName().toString()));
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(band, verifiedMusicians)));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddMusicianToBandCommand)) {
+            return false;
+        }
+
+        AddMusicianToBandCommand otherAddMusicianToBandCommand = (AddMusicianToBandCommand) other;
+        return musiciansToAdd.equals(otherAddMusicianToBandCommand.musiciansToAdd)
+                && bandToAddInto.equals(otherAddMusicianToBandCommand.bandToAddInto);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/band/RemoveMusicianFromBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/band/RemoveMusicianFromBandCommand.java
@@ -75,4 +75,20 @@ public class RemoveMusicianFromBandCommand extends Command {
 
         return lastShownMusicianList.get(musicianTargetIndex.getZeroBased());
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RemoveMusicianFromBandCommand)) {
+            return false;
+        }
+
+        RemoveMusicianFromBandCommand otherRemoveMusicianFromBandCommand = (RemoveMusicianFromBandCommand) other;
+        return bandTargetIndex.equals(otherRemoveMusicianFromBandCommand.bandTargetIndex)
+                && musicianTargetIndex.equals(otherRemoveMusicianFromBandCommand.musicianTargetIndex);
+    }
 }


### PR DESCRIPTION
The equals method for the AddMusicianToBandCommand and RemoveMusicianFromBandCommand classes were not overwritten.

This commit overwrites the equals method to reflect the intended behaviour.