### PR TITLE
Check duplicate phone/email when edit musician

### DIFF
--- a/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/AddCommand.java
@@ -61,7 +61,7 @@ public class AddCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_MUSICIAN);
         }
 
-        if (model.hasDuplicateInfo(toAdd)) {
+        if (model.hasDuplicateInfo(null, toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_INFO);
         }
 

--- a/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/musician/EditCommand.java
@@ -54,6 +54,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_MUSICIAN_SUCCESS = "Edited Musician: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_MUSICIAN = "This musician already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_INFO = "Phone number or email already exists in your contact list!";
 
     private final Index index;
     private final EditMusicianDescriptor editMusicianDescriptor;
@@ -84,6 +85,10 @@ public class EditCommand extends Command {
 
         if (!musicianToEdit.isSameMusician(editedMusician) && model.hasMusician(editedMusician)) {
             throw new CommandException(MESSAGE_DUPLICATE_MUSICIAN);
+        }
+
+        if (model.hasDuplicateInfo(musicianToEdit, editedMusician)) {
+            throw new CommandException(MESSAGE_DUPLICATE_INFO);
         }
 
         // update musician list to show all, update band list to show all, update bands musicians

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -78,9 +78,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Returns true if a musician with the same phone or email as {@code musician} exists in the address book.
      */
-    public boolean hasDuplicateInfo(Musician musician) {
+    public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
         requireNonNull(musician);
-        return musicians.hasDuplicateInfo(musician);
+        return musicians.hasDuplicateInfo(toExclude, musician);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -62,7 +62,7 @@ public interface Model {
     /**
      * Returns true if a musician with the same phone or email as {@code musician} exists in the address book.
      */
-    boolean hasDuplicateInfo(Musician musician);
+    boolean hasDuplicateInfo(Musician toExclude, Musician musician);
 
     /**
      * Deletes the given musician.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -98,9 +98,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasDuplicateInfo(Musician musician) {
+    public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
         requireNonNull(musician);
-        return addressBook.hasDuplicateInfo(musician);
+        return addressBook.hasDuplicateInfo(toExclude, musician);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/musician/UniqueMusicianList.java
+++ b/src/main/java/seedu/address/model/musician/UniqueMusicianList.java
@@ -41,9 +41,11 @@ public class UniqueMusicianList implements Iterable<Musician> {
     /**
      * Returns true if the list contains an musician with the same phone or email as the given argument.
      */
-    public boolean hasDuplicateInfo(Musician toCheck) {
+    public boolean hasDuplicateInfo(Musician toExclude, Musician toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::hasSameInfo);
+        return internalList.stream()
+                .filter(musician -> !musician.isSameMusician(toExclude))
+                .anyMatch(toCheck::hasSameInfo);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddBandCommandTest.java
@@ -121,8 +121,9 @@ public class AddBandCommandTest {
         public void addMusician(Musician musician) {
             throw new AssertionError("This method should not be called.");
         }
+
         @Override
-        public boolean hasDuplicateInfo(Musician musician) {
+        public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddMusicianToBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMusicianToBandCommandTest.java
@@ -184,7 +184,7 @@ public class AddMusicianToBandCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public boolean hasDuplicateInfo(Musician musician) {
+        public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
             throw new AssertionError("This method should not be called.");
         }
         @Override
@@ -315,9 +315,9 @@ public class AddMusicianToBandCommandTest {
             return musiciansAdded.contains(musician);
         }
         @Override
-        public boolean hasDuplicateInfo(Musician musician) {
+        public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
             requireNonNull(musician);
-            return musiciansAdded.hasDuplicateInfo(musician);
+            return musiciansAdded.hasDuplicateInfo(null, musician);
         }
         @Override
         public ObservableList<Band> getFilteredBandList() {

--- a/src/test/java/seedu/address/logic/commands/musician/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/musician/AddCommandTest.java
@@ -126,7 +126,7 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
         @Override
-        public boolean hasDuplicateInfo(Musician musician) {
+        public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
             throw new AssertionError("This method should not be called.");
         }
         @Override
@@ -252,7 +252,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasDuplicateInfo(Musician musician) {
+        public boolean hasDuplicateInfo(Musician toExclude, Musician musician) {
             requireNonNull(musician);
             return musiciansAdded.stream().anyMatch(musician::hasSameInfo);
         }


### PR DESCRIPTION
This PR fixes #162 #164 

In this PR, I modified the edit command to check for duplicate phone or email field before allowing the edits.