### PR TITLE
Fix bugs about name and band name as UID, write tests

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -18,7 +18,7 @@ public class StringUtil {
      *   <br>examples:<pre>
      *       containsWordIgnoreCase("ABc def", "abc") == true
      *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == false //not a full word match
+     *       containsWordIgnoreCase("ABc def", "AB") == false // not a full word match
      *       </pre>
      * @param sentence cannot be null
      * @param word cannot be null, cannot be empty, must be a single word
@@ -36,6 +36,27 @@ public class StringUtil {
 
         return Arrays.stream(wordsInPreppedSentence)
                 .anyMatch(preppedWord::equalsIgnoreCase);
+    }
+
+    /**
+     * Returns true if the {@code phrase1} and the {@code phrase2} contain the exact same words in the same order.
+     * Ignore case, and leading, trailing, and intermediate whitespaces.
+     *   <br>examples:<pre>
+     *       hasSameWordsInSameSequenceIgnoreCase("ABc def", "abc deF") == true
+     *       hasSameWordsInSameSequenceIgnoreCase("ABc def", "abc    def") == true
+     *       hasSameWordsInSameSequenceIgnoreCase("ABc def", "def Abc") == false // not in the same sequence
+     *       </pre>
+     * @param phrase1 cannot be null
+     * @param phrase2 cannot be null
+     */
+    public static boolean hasSameWordsInSameSequenceIgnoreCase(String phrase1, String phrase2) {
+        requireNonNull(phrase1);
+        requireNonNull(phrase2);
+
+        String processedPhrase1 = phrase1.trim().replaceAll("\\s+", "");
+        String processedPhrase2 = phrase2.trim().replaceAll("\\s+", "");
+
+        return processedPhrase1.equalsIgnoreCase(processedPhrase2);
     }
 
     /**

--- a/src/main/java/seedu/address/model/band/BandName.java
+++ b/src/main/java/seedu/address/model/band/BandName.java
@@ -3,6 +3,8 @@ package seedu.address.model.band;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.StringUtil;
+
 /**
  * Represents a Band's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -56,7 +58,7 @@ public class BandName {
         }
 
         BandName otherName = (BandName) other;
-        return fullName.equalsIgnoreCase(otherName.fullName);
+        return StringUtil.hasSameWordsInSameSequenceIgnoreCase(fullName, otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/musician/Name.java
+++ b/src/main/java/seedu/address/model/musician/Name.java
@@ -3,6 +3,8 @@ package seedu.address.model.musician;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import seedu.address.commons.util.StringUtil;
+
 /**
  * Represents a Musician's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
@@ -44,6 +46,11 @@ public class Name {
         return fullName;
     }
 
+    /**
+     * Returns true if the names are the same (case-insensitive).
+     * @param other the other name to compare with.
+     * @return true if both names are the same (case-insensitive).
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -56,7 +63,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return StringUtil.hasSameWordsInSameSequenceIgnoreCase(fullName, otherName.fullName);
     }
 
     @Override

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,11 +123,51 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));
     }
 
+    //---------------- Tests for hasSameWordsInSameSequenceIgnoreCase --------------------------------------
+
+    /*
+     * Equivalence Partitions for a phrase: null, empty string, valid string
+     */
+
     //---------------- Tests for getDetails --------------------------------------
 
     /*
-     * Equivalence Partitions: null, valid throwable object
+     * Invalid equivalence partitions for a phrase: null (same for both phrase1 and phrase2)
+     * The test case below test the invalid input.
      */
+    @Test
+    public void hasSameWordsInSameSequenceIgnoreCase_nullPhrase_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> StringUtil.hasSameWordsInSameSequenceIgnoreCase(null, "abc"));
+        assertThrows(NullPointerException.class, () -> StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc", null));
+    }
+
+    /*
+     * Valid equivalence partitions for a phrase:
+     *   - empty string
+     *   - one word
+     *   - one word with leading/trailing spaces
+     *   - multiple words separated by spaces
+     *   - multiple words separated by extra spaces
+     *
+     * The test method below tries to verify all above with a reasonably low number of test cases.
+     */
+    @Test
+    public void hasSameWordsInSameSequenceIgnoreCase_validInputs_correctResult() {
+        // empty string
+        assertFalse(StringUtil.hasSameWordsInSameSequenceIgnoreCase("", "abc")); // Boundary case
+        assertFalse(StringUtil.hasSameWordsInSameSequenceIgnoreCase("  ", "abc")); // Boundary case
+
+        // one word with leading/trailing spaces
+        assertTrue(StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc", "ABC")); // case insensitive
+        assertTrue(StringUtil.hasSameWordsInSameSequenceIgnoreCase("123abc", "123ABC")); // with numbers
+        assertTrue(StringUtil.hasSameWordsInSameSequenceIgnoreCase("   abc", "ABC  ")); // leading and trailing spaces
+        assertFalse(StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc", "ABCD")); // different word
+
+        // multiple words separated by possibly extra spaces
+        assertTrue(StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc def", "ABCDEF")); // remove spaces between words
+        assertTrue(StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc def", "  ABC   DEF  ")); // extra spaces
+        assertFalse(StringUtil.hasSameWordsInSameSequenceIgnoreCase("abc def", "DEF ABC")); // different sequence
+    }
 
     @Test
     public void getDetails_exceptionGiven() {

--- a/src/test/java/seedu/address/model/band/BandNameTest.java
+++ b/src/test/java/seedu/address/model/band/BandNameTest.java
@@ -56,6 +56,12 @@ public class BandNameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new BandName("Other Valid Name")));
+
+        // different case -> returns true
+        assertTrue(name.equals(new BandName("valid name")));
+
+        // extra whitespaces -> returns true
+        assertTrue(name.equals(new BandName("Valid   Name  ")));
     }
 }
 

--- a/src/test/java/seedu/address/model/musician/MusicianTest.java
+++ b/src/test/java/seedu/address/model/musician/MusicianTest.java
@@ -40,13 +40,24 @@ public class MusicianTest {
         editedAlice = new MusicianBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSameMusician(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Musician editedBob = new MusicianBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameMusician(editedBob));
+        assertTrue(BOB.isSameMusician(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new MusicianBuilder(BOB).withName(nameWithTrailingSpaces).build();
+        // name has leading, trailing, and extra spaces, all other attributes same -> returns true
+        String nameWithExtraSpaces = VALID_NAME_BOB.replaceAll("\\s+", "   ") + " ";
+        editedBob = new MusicianBuilder(BOB).withName(nameWithExtraSpaces).build();
+        assertTrue(BOB.isSameMusician(editedBob));
+
+        // name with no spaces, all other attributes same -> returns true
+        String nameWithNoSpaces = VALID_NAME_BOB.replaceAll("\\s+", "");
+        editedBob = new MusicianBuilder(BOB).withName(nameWithNoSpaces).build();
+        assertTrue(BOB.isSameMusician(editedBob));
+
+        // name with inverted first name and last name, all other attributes same -> returns false
+        String nameWithInvertedFirstAndLastName = VALID_NAME_BOB.split("\\s+")[1]
+                + " " + VALID_NAME_BOB.split("\\s+")[0];
+        editedBob = new MusicianBuilder(BOB).withName(nameWithInvertedFirstAndLastName).build();
         assertFalse(BOB.isSameMusician(editedBob));
     }
 

--- a/src/test/java/seedu/address/model/musician/NameTest.java
+++ b/src/test/java/seedu/address/model/musician/NameTest.java
@@ -27,6 +27,7 @@ public class NameTest {
         // invalid name
         assertFalse(Name.isValidName("")); // empty string
         assertFalse(Name.isValidName(" ")); // spaces only
+        assertFalse(Name.isValidName(" Peter")); // name begins with space
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
 
@@ -56,5 +57,11 @@ public class NameTest {
 
         // different values -> returns false
         assertFalse(name.equals(new Name("Other Valid Name")));
+
+        // different case -> returns true
+        assertTrue(name.equals(new Name("valid name")));
+
+        // extra whitespaces -> returns true
+        assertTrue(name.equals(new Name("Valid   Name  ")));
     }
 }


### PR DESCRIPTION
Since name is a unique identifier (UID) for both musicians and bands, I enforce the following rule to give a closer-to-real-life definition of "two names being equal":

**two names containing the same words (case-insensitive) in the same sequence ignoring any leading, trailing, and intermediate whitespace are considered equal**

Examples of names that are _equal_ to each other:
- "john doe" and "JOHN DOE"
- "john doe" and "john    DOE"
- "john doe" and "johnDoe"

Examples of names that are _NOT equal_ to each other:
- "john doe" and "doe john"
- "john doe" and "john"