### PR TITLE
Move band test classes to 'commands.band'

### DIFF
--- a/src/test/java/seedu/address/logic/commands/band/FindBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/band/FindBandCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.band;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.band.FindBandCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/band/RemoveMusicianFromBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/band/RemoveMusicianFromBandCommandTest.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.logic.commands.band;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.band.RemoveMusicianFromBandCommand;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;


### PR DESCRIPTION
This PR contains the following minor changes:

- Refactor `FindBandCommandTest` and `RemoveMusicianFromBandCommandTest` to package `seedu.address.logic.commands.band`
- Remove unnecessary import statements