### PR TITLE
Fix a bug where FindBandCommand incorrectly handles empty band list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/band/FindBandCommand.java
+++ b/src/main/java/seedu/address/logic/commands/band/FindBandCommand.java
@@ -25,6 +25,7 @@ public class FindBandCommand extends Command {
         + "Example: " + COMMAND_WORD + " BlackPink";
 
     public static final String MESSAGE_SUCCESS = "There are %1$d musicians in the band %2$s";
+    public static final String MESSAGE_NO_BAND_IN_LIST = "No bands yet." + "\n" + "Please create a band first!";
     private final Predicate<Band> predicate;
 
     public FindBandCommand(Predicate<Band> predicate) {
@@ -34,8 +35,11 @@ public class FindBandCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        model.updateFilteredBandMusicianList(predicate);
+        if (model.getFilteredBandList().isEmpty()) {
+            throw new CommandException(MESSAGE_NO_BAND_IN_LIST);
+        }
 
+        model.updateFilteredBandMusicianList(predicate);
         // If the band exists, filtered band list is guaranteed to have only one band,
         // (because add a band enforce no band with the same name (case-insensitive) is allowed).
         // If filtered band list size > 1 or size == 1 but the band filtered does not pass the predicate,

--- a/src/test/java/seedu/address/logic/commands/band/FindBandCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/band/FindBandCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.band.FindBandCommand.MESSAGE_NO_BAND_IN_LIST;
 import static seedu.address.testutil.typicalentities.TypicalAddressBook.getOneBandAddressBook;
 import static seedu.address.testutil.typicalentities.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.typicalentities.TypicalBands.ACE;
@@ -21,10 +22,12 @@ import static seedu.address.testutil.typicalentities.TypicalMusicians.FIONA;
 import static seedu.address.testutil.typicalentities.TypicalMusicians.GEORGE;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -35,6 +38,7 @@ class FindBandCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Test
     void execute_validBandNameNoMusician_success() {
         String expectedMessage = String.format(FindBandCommand.MESSAGE_SUCCESS, 0, "Ace Jazz");
@@ -57,6 +61,26 @@ class FindBandCommandTest {
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, DANIEL), model.getFilteredMusicianList());
         assertEquals(Arrays.asList(DRAGON), model.getFilteredBandList());
+    }
+
+    @Test
+    void execute_noBandInList_throwsCommandException() {
+        // First initialise empty AddressBooks
+        model = new ModelManager(new AddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(new AddressBook(), new UserPrefs());
+
+        BandNameContainsKeywordsPredicate predicate = new BandNameContainsKeywordsPredicate("test");
+        expectedModel.updateFilteredBandMusicianList(predicate);
+
+        // Message should be shown, and no runtime exception should be thrown.
+        FindBandCommand command = new FindBandCommand(predicate);
+        assertCommandFailure(command, model, MESSAGE_NO_BAND_IN_LIST);
+        assertEquals(List.of(), model.getFilteredMusicianList()); // Empty musician list
+        assertEquals(List.of(), model.getFilteredBandList()); // Empty band list
+
+        // Reset model and expectedModel back for other tests
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     }
 
     @Test


### PR DESCRIPTION
Fixes the bug mentioned in [\#234](https://github.com/AY2324S1-CS2103T-W11-3/tp/issues/234).

An additional negative test case is also added in `FindBandCommandTest` to verify the intended behaviour.